### PR TITLE
[Misc] update dependencies' version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ edition = "2018"
 
 [dependencies]
 unicase = "^2.6"
-wasmedge_wasi_socket = "0.1.0"
+wasmedge_wasi_socket = "0.2.0"


### PR DESCRIPTION
Fix the bug that the version of wasmedge_wasi_socket dependence  is not the latest.