### PR TITLE
add the https support and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,24 @@ fn main() {
 wasmedge_http_req  = "0.8.1"
 ```
 
+## HTTPS support
+The HTTP and HTTPS APIs are the same. The Err messages are presented differently because the HTTP uses the rust code while the HTTPS request uses a wasmedge host function. 
+
+build the wasmedge
+```
+sudo apt-get install libssl-dev
+cmake -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_TESTS=OFF -DWASMEDGE_PLUGIN_HTTPSREQ=true  .. && make -j4
+```
+
+Basic HTTPS GET request
+
+```rust
+use wasmedge_http_req::request;
+
+fn main() {
+    let mut writer = Vec::new(); //container for body of a response
+    let res = request::get("https://127.0.0.1/", &mut writer).unwrap();
+
+    println!("Status: {} {}", res.status_code(), res.reason());
+}
+```

--- a/examples/get_https.rs
+++ b/examples/get_https.rs
@@ -1,0 +1,10 @@
+use wasmedge_http_req::request;
+
+fn main() {
+    let mut writer = Vec::new(); //container for body of a response
+    let res = request::get("https://httpbin.org/get", &mut writer).unwrap();
+
+    println!("Status: {} {}", res.status_code(), res.reason());
+    println!("Headers {}", res.headers());
+    //println!("{}", String::from_utf8_lossy(&writer));
+}

--- a/examples/head_https.rs
+++ b/examples/head_https.rs
@@ -1,0 +1,8 @@
+use wasmedge_http_req::request;
+
+fn main() {
+    let res = request::head("https://httpbin.org/head").unwrap();
+
+    println!("Status: {} {}", res.status_code(), res.reason());
+    println!("{:?}", res.headers());
+}

--- a/examples/post_https.rs
+++ b/examples/post_https.rs
@@ -1,0 +1,11 @@
+use wasmedge_http_req::request;
+
+fn main() {
+    let mut writer = Vec::new(); //container for body of a response
+    const BODY: &[u8; 27] = b"field1=value1&field2=value2";
+    let res = request::post("https://httpbin.org/post", BODY, &mut writer).unwrap();
+
+    println!("Status: {} {}", res.status_code(), res.reason());
+    println!("Headers {}", res.headers());
+    //println!("{}", String::from_utf8_lossy(&writer));  // uncomment this line to display the content of writer
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 pub mod error;
 pub mod request;
 pub mod response;
+pub mod sslwrapper;
 // pub mod tls;
 pub mod uri;
 

--- a/src/sslwrapper.rs
+++ b/src/sslwrapper.rs
@@ -1,0 +1,49 @@
+use std::ffi::CString;
+
+pub struct Output {
+    // the received data
+    pub rcv_vec: Vec<u8>,
+}
+
+pub mod sslwrapper {
+    use std::os::raw::c_char;
+    #[link(wasm_import_module = "httpsreq")]
+    extern "C" {
+        pub fn send_data(
+            host: *const c_char,
+            hostlen: u32,
+            port: u32,
+            body: *const c_char,
+            bodylen: u32,
+        );
+        pub fn get_rcv(Rcv: *mut u8);
+        pub fn get_rcv_len() -> u32;
+    }
+}
+
+pub fn send_data<S: AsRef<str>>(host: S, port: u32, body: S) {
+    let host = CString::new((host.as_ref()).as_bytes()).expect("");
+    let body = CString::new((body.as_ref()).as_bytes()).expect("");
+    unsafe {
+        sslwrapper::send_data(
+            host.as_ptr(),
+            host.as_bytes().len() as u32,
+            port,
+            body.as_ptr(),
+            body.as_bytes().len() as u32,
+        );
+    }
+}
+
+pub fn get_receive() -> Output {
+    let rcv_len: u32;
+    unsafe {
+        rcv_len = sslwrapper::get_rcv_len();
+    }
+    let mut rcv: Vec<u8> = vec![0; rcv_len as usize];
+    let rev_ptr = rcv.as_mut_ptr();
+    unsafe {
+        sslwrapper::get_rcv(rev_ptr);
+    }
+    Output { rcv_vec: rcv }
+}


### PR DESCRIPTION
### Https support

[issue #1530](https://github.com/WasmEdge/WasmEdge/issues/1530)

current wasmedge code: https://github.com/2019zhou/WasmEdge/tree/zhou/httpsreq

- build the wasmedge
```
sudo apt-get install libssl-dev
cmake -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_TESTS=OFF -DWASMEDGE_PLUGIN_HTTPSREQ=true  .. && make -j4
```
Basic HTTPS GET request

```rust
use wasmedge_http_req::request;

fn main() {
    let mut writer = Vec::new(); //container for body of a response
    let res = request::get("https://127.0.0.1/", &mut writer).unwrap();

    println!("Status: {} {}", res.status_code(), res.reason());
}
```
