### PR TITLE
[Example] add example for wasmedge_http_req

### DIFF
--- a/examples/add_headers.rs
+++ b/examples/add_headers.rs
@@ -1,0 +1,30 @@
+use std::convert::TryFrom;
+use wasmedge_http_req::{request::{Request, HttpVersion}, response::Headers, uri::Uri};
+
+fn main() {
+    let mut writer = Vec::new();
+    let uri = Uri::try_from("http://httpbin.org/get").unwrap();
+    // let uri = Uri::try_from("https://httpbin.org/get").unwrap(); // uncomment the line for https request
+
+    // add headers to the request
+    let mut headers = Headers::new();
+    headers.insert("Accept-Charset", "utf-8");
+    headers.insert("Accept-Language", "en-US");
+    headers.insert("Host", "rust-lang.org");
+    headers.insert("Connection", "Close");
+    
+    let mut response = Request::new(&uri)
+        .headers(headers)
+        .send(&mut writer)
+        .unwrap();
+
+    println!("{}", String::from_utf8_lossy(&writer));
+
+    // set version
+    response = Request::new(&uri)
+        .version(HttpVersion::Http10)
+        .send(&mut writer)
+        .unwrap();
+    
+    println!("{}", String::from_utf8_lossy(&writer));
+}

--- a/src/sslwrapper.rs
+++ b/src/sslwrapper.rs
@@ -7,17 +7,17 @@ pub struct Output {
 
 pub mod sslwrapper {
     use std::os::raw::c_char;
-    #[link(wasm_import_module = "httpsreq")]
+    #[link(wasm_import_module = "wasmedge_httpsreq")]
     extern "C" {
-        pub fn send_data(
+        pub fn wasmedge_httpsreq_send_data(
             host: *const c_char,
             hostlen: u32,
             port: u32,
             body: *const c_char,
             bodylen: u32,
         );
-        pub fn get_rcv(Rcv: *mut u8);
-        pub fn get_rcv_len() -> u32;
+        pub fn wasmedge_httpsreq_get_rcv(Rcv: *mut u8);
+        pub fn wasmedge_httpsreq_get_rcv_len() -> u32;
     }
 }
 
@@ -25,7 +25,7 @@ pub fn send_data<S: AsRef<str>>(host: S, port: u32, body: S) {
     let host = CString::new((host.as_ref()).as_bytes()).expect("");
     let body = CString::new((body.as_ref()).as_bytes()).expect("");
     unsafe {
-        sslwrapper::send_data(
+        sslwrapper::wasmedge_httpsreq_send_data(
             host.as_ptr(),
             host.as_bytes().len() as u32,
             port,
@@ -38,12 +38,12 @@ pub fn send_data<S: AsRef<str>>(host: S, port: u32, body: S) {
 pub fn get_receive() -> Output {
     let rcv_len: u32;
     unsafe {
-        rcv_len = sslwrapper::get_rcv_len();
+        rcv_len = sslwrapper::wasmedge_httpsreq_get_rcv_len();
     }
     let mut rcv: Vec<u8> = vec![0; rcv_len as usize];
     let rev_ptr = rcv.as_mut_ptr();
     unsafe {
-        sslwrapper::get_rcv(rev_ptr);
+        sslwrapper::wasmedge_httpsreq_get_rcv(rev_ptr);
     }
     Output { rcv_vec: rcv }
 }


### PR DESCRIPTION
Signed-off-by: zhouzhou <juliazhou2019@outlook.com>

Add examples for wasmedge_http_req including adding headers and setting version information. The examples can be used for HTTP and HTTPS requests. 